### PR TITLE
Various improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ docs/build
 htmlcov
 .docker
 .idea/
+.vscode/

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 FNNDSC / BCH
+Copyright (c) 2017-2020 FNNDSC / BCH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/{{cookiecutter.app_repo_name}}/.gitignore
+++ b/{{cookiecutter.app_repo_name}}/.gitignore
@@ -7,3 +7,4 @@ docs/build
 htmlcov
 .docker
 .idea/
+.vscode/

--- a/{{cookiecutter.app_repo_name}}/Dockerfile
+++ b/{{cookiecutter.app_repo_name}}/Dockerfile
@@ -26,13 +26,8 @@
 FROM fnndsc/ubuntu-python3:latest
 MAINTAINER fnndsc "dev@babymri.org"
 
-ENV APPROOT="/usr/src/{{ cookiecutter.app_name }}"
-COPY ["{{ cookiecutter.app_name }}", "${APPROOT}"]
-COPY ["requirements.txt", "${APPROOT}"]
+WORKDIR /usr/local/src/
+COPY . /usr/local/src/
+RUN ["pip", "install", "/usr/local/src"]
 
-WORKDIR $APPROOT
-
-RUN pip install --upgrade pip
-RUN pip install -r requirements.txt
-
-CMD ["{{ cookiecutter.app_name }}.py", "--help"]
+CMD ["/usr/local/bin/{{ cookiecutter.app_name }}", "--help"]

--- a/{{cookiecutter.app_repo_name}}/LICENSE
+++ b/{{cookiecutter.app_repo_name}}/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 FNNDSC / BCH
+Copyright (c) 2017-2020 FNNDSC / BCH
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/{{cookiecutter.app_repo_name}}/requirements.txt
+++ b/{{cookiecutter.app_repo_name}}/requirements.txt
@@ -1,2 +1,1 @@
-chrisapp
-pudb
+chrisapp~=1.1.6

--- a/{{cookiecutter.app_repo_name}}/setup.py
+++ b/{{cookiecutter.app_repo_name}}/setup.py
@@ -1,37 +1,25 @@
-
-import sys
-import os
-
-
-# Make sure we are running python3.5+
-if 10 * sys.version_info[0] + sys.version_info[1] < 35:
-    sys.exit("Sorry, only Python 3.5+ is supported.")
-
-
+from os import path
 from setuptools import setup
 
-
-def readme():
-    print("Current dir = %s" % os.getcwd())
-    print(os.listdir())
-    with open('README.rst') as f:
-        return f.read()
+with open(path.join(path.abspath(path.dirname(__file__)), 'README.rst')) as f:
+    readme = f.read()
 
 setup(
-      name             =   '{{ cookiecutter.app_name }}',
-      # for best practices make this version the same as the VERSION class variable
-      # defined in your ChrisApp-derived Python class
-      version          =   '{{ cookiecutter.app_version }}',
-      description      =   '{{ cookiecutter.app_description }}',
-      long_description =   readme(),
-      author           =   '{{ cookiecutter.author_name }}',
-      author_email     =   '{{ cookiecutter.author_email }}',
-      url              =   '{{ cookiecutter.app_documentation }}',
-      packages         =   ['{{ cookiecutter.app_name }}'],
-      install_requires =   ['chrisapp', 'pudb'],
-      test_suite       =   'nose.collector',
-      tests_require    =   ['nose'],
-      scripts          =   ['{{ cookiecutter.app_name }}/{{ cookiecutter.app_name }}.py'],
-      license          =   'MIT',
-      zip_safe         =   False
-     )
+    name             = '{{ cookiecutter.app_name }}',
+    # for best practices make this version the same as the VERSION class variable
+    # defined in your ChrisApp-derived Python class
+    version          = '{{ cookiecutter.app_version }}',
+    description      = '{{ cookiecutter.app_description }}',
+    long_description = readme,
+    author           = '{{ cookiecutter.author_name }}',
+    author_email     = '{{ cookiecutter.author_email }}',
+    url              = '{{ cookiecutter.app_documentation }}',
+    packages         = ['{{ cookiecutter.app_name }}'],
+    install_requires = ['chrisapp~=1.1.6'],
+    test_suite       = 'nose.collector',
+    tests_require    = ['nose'],
+    scripts          = ['{{ cookiecutter.app_name }}/{{ cookiecutter.app_name }}.py'],
+    license          = 'MIT',
+    zip_safe         = False,
+    python_requires  = '>=3.5',
+)

--- a/{{cookiecutter.app_repo_name}}/setup.py
+++ b/{{cookiecutter.app_repo_name}}/setup.py
@@ -6,8 +6,6 @@ with open(path.join(path.abspath(path.dirname(__file__)), 'README.rst')) as f:
 
 setup(
     name             = '{{ cookiecutter.app_name }}',
-    # for best practices make this version the same as the VERSION class variable
-    # defined in your ChrisApp-derived Python class
     version          = '{{ cookiecutter.app_version }}',
     description      = '{{ cookiecutter.app_description }}',
     long_description = readme,

--- a/{{cookiecutter.app_repo_name}}/setup.py
+++ b/{{cookiecutter.app_repo_name}}/setup.py
@@ -16,8 +16,12 @@ setup(
     install_requires = ['chrisapp~=1.1.6'],
     test_suite       = 'nose.collector',
     tests_require    = ['nose'],
-    scripts          = ['{{ cookiecutter.app_name }}/{{ cookiecutter.app_name }}.py'],
     license          = 'MIT',
     zip_safe         = False,
     python_requires  = '>=3.5',
+    entry_points     = {
+        'console_scripts': [
+            '{{ cookiecutter.app_name }} = {{ cookiecutter.app_name }}.__main__:main'
+            ]
+        }
 )

--- a/{{cookiecutter.app_repo_name}}/{{cookiecutter.app_name}}/__main__.py
+++ b/{{cookiecutter.app_repo_name}}/{{cookiecutter.app_name}}/__main__.py
@@ -1,0 +1,10 @@
+from .{{ cookiecutter.app_name }} import {{ cookiecutter.app_python_class_name }}
+
+
+def main():
+    chris_app = {{ cookiecutter.app_python_class_name }}()
+    chris_app.launch()
+
+
+if __name__ == "__main__":
+    main()

--- a/{{cookiecutter.app_repo_name}}/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}.py
+++ b/{{cookiecutter.app_repo_name}}/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}.py
@@ -144,9 +144,3 @@ class {{ cookiecutter.app_python_class_name }}(ChrisApp):
         Print the app's man page.
         """
         print(Gstr_synopsis)
-
-
-# ENTRYPOINT
-if __name__ == "__main__":
-    chris_app = {{ cookiecutter.app_python_class_name }}()
-    chris_app.launch()

--- a/{{cookiecutter.app_repo_name}}/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}.py
+++ b/{{cookiecutter.app_repo_name}}/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}.py
@@ -2,7 +2,7 @@
 #
 # {{ cookiecutter.app_name }} {{ cookiecutter.app_type }} ChRIS plugin app
 #
-# (c) 2016-2019 Fetal-Neonatal Neuroimaging & Developmental Science Center
+# (c) 2016-2020 Fetal-Neonatal Neuroimaging & Developmental Science Center
 #                   Boston Children's Hospital
 #
 #              http://childrenshospital.org/FNNDSC/
@@ -92,10 +92,10 @@ class {{ cookiecutter.app_python_class_name }}(ChrisApp):
     """
     {{ cookiecutter.app_description }}.
     """
-    AUTHORS                 = '{{ cookiecutter.author_name }} ({{ cookiecutter.author_email }})'
+    AUTHORS                 = '{{ cookiecutter.author_name }} <{{ cookiecutter.author_email }}>'
     SELFPATH                = os.path.dirname(os.path.abspath(__file__))
     SELFEXEC                = os.path.basename(__file__)
-    EXECSHELL               = 'python3'
+    EXECSHELL               = 'python'
     TITLE                   = '{{ cookiecutter.app_title }}'
     CATEGORY                = '{{ cookiecutter.app_category }}'
     TYPE                    = '{{ cookiecutter.app_type }}'

--- a/{{cookiecutter.app_repo_name}}/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}.py
+++ b/{{cookiecutter.app_repo_name}}/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}.py
@@ -12,9 +12,9 @@
 
 import os
 import sys
+import importlib.metadata
 sys.path.append(os.path.dirname(__file__))
 
-# import the Chris app superclass
 from chrisapp.base import ChrisApp
 
 
@@ -101,7 +101,7 @@ class {{ cookiecutter.app_python_class_name }}(ChrisApp):
     TYPE                    = '{{ cookiecutter.app_type }}'
     DESCRIPTION             = '{{ cookiecutter.app_description }}'
     DOCUMENTATION           = '{{ cookiecutter.app_documentation }}'
-    VERSION                 = '{{ cookiecutter.app_version }}'
+    VERSION                 = importlib.metadata.version(__package__)
     ICON                    = '' # url of an icon image
     LICENSE                 = 'Opensource (MIT)'
     MAX_NUMBER_OF_WORKERS   = 1  # Override with integer value


### PR DESCRIPTION
- `pip install <folder>` is the proper way to install a module
- `entry_points` is the proper way to publish a python script
- "version" comes from `setup.py`
- separate main/driver code to its own file—isolate boilerplate from the important source file
- small doc changes

feel free to cherry-pick whichever features you like and whichever you do not