### PR TITLE
Set CWD in Dockerfile to bin folder

### DIFF
--- a/{{cookiecutter.app_repo_name}}/Dockerfile
+++ b/{{cookiecutter.app_repo_name}}/Dockerfile
@@ -28,5 +28,6 @@ WORKDIR /usr/local/src
 COPY . .
 RUN ["pip", "--disable-pip-version-check", "install", "/usr/local/src"]
 
-CMD ["/usr/local/bin/{{ cookiecutter.app_name }}", "--help"]
+WORKDIR /usr/local/bin
+CMD ["{{ cookiecutter.app_name }}", "--help"]
 


### PR DESCRIPTION
The status quo is to run a plugin like

```bash
docker run --rm fnndsc/pl-app pl-app --flag var /in /out
```

Which implicitly expands out to

```bash
docker run --rm --workdir /usr/local/srv/pl-app --entrypoint /usr/bin/python fnndsc/pl-app pl-app --flag var /in /out
```

For the sake of maintaining the status quo, the `Dockerfile` should set CWD to where the executables are located, so that the name of the plugin must be given in the command to run.

Instead of using the `Dockerfile` as a ground truth for how plugins should be run, ChRIS uses the `EXECSHELL`, `SELFPATH`, and `SELFEXEC` Python class attributes.