### PR TITLE
Plugin description single source of truth in setup.py

### DIFF
--- a/{{cookiecutter.app_repo_name}}/Dockerfile
+++ b/{{cookiecutter.app_repo_name}}/Dockerfile
@@ -26,11 +26,11 @@ MAINTAINER fnndsc "dev@babymri.org"
 
 WORKDIR /usr/local/src
 COPY . .
-RUN pip --disable-pip-version-check install -r requirements.txt && pip install .
+RUN pip --disable-pip-version-check install -r requirements.txt \
+    && pip --disable-pip-version-check install .
 
 # the precedent is for a plugin to be run like
 # docker run --entrypoint /usr/bin/python fnndsc/pl-appname appname /in /out
 # executable scripts are expected to be found in the working directory
 WORKDIR /usr/local/bin
 CMD ["{{ cookiecutter.app_name }}", "--help"]
-

--- a/{{cookiecutter.app_repo_name}}/setup.py
+++ b/{{cookiecutter.app_repo_name}}/setup.py
@@ -13,7 +13,7 @@ setup(
     author_email     = '{{ cookiecutter.author_email }}',
     url              = '{{ cookiecutter.app_documentation }}',
     packages         = ['{{ cookiecutter.app_name }}'],
-    install_requires = ['chrisapp~=1.1.6'],
+    install_requires = ['chrisapp~=2.0.0'],
     test_suite       = 'nose.collector',
     tests_require    = ['nose'],
     license          = 'MIT',

--- a/{{cookiecutter.app_repo_name}}/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}.py
+++ b/{{cookiecutter.app_repo_name}}/{{cookiecutter.app_name}}/{{cookiecutter.app_name}}.py
@@ -9,10 +9,6 @@
 #                        dev@babyMRI.org
 #
 
-
-import os
-import importlib.metadata
-
 from chrisapp.base import ChrisApp
 
 
@@ -90,18 +86,10 @@ class {{ cookiecutter.app_python_class_name }}(ChrisApp):
     """
     {{ cookiecutter.app_description }}
     """
-    AUTHORS                 = '{{ cookiecutter.author_name }} <{{ cookiecutter.author_email }}>'
-    SELFPATH                = '/usr/local/bin'
-    SELFEXEC                = '{{ cookiecutter.app_name }}'
-    EXECSHELL               = 'python'
-    TITLE                   = '{{ cookiecutter.app_title }}'
+    PACKAGE                 = __package__
     CATEGORY                = '{{ cookiecutter.app_category }}'
     TYPE                    = '{{ cookiecutter.app_type }}'
-    DESCRIPTION             = '{{ cookiecutter.app_description }}'
-    DOCUMENTATION           = '{{ cookiecutter.app_documentation }}'
-    VERSION                 = importlib.metadata.version(__package__)
     ICON                    = '' # url of an icon image
-    LICENSE                 = 'Opensource (MIT)'
     MAX_NUMBER_OF_WORKERS   = 1  # Override with integer value
     MIN_NUMBER_OF_WORKERS   = 1  # Override with integer value
     MAX_CPU_LIMIT           = '' # Override with millicore value as string, e.g. '2000m'


### PR DESCRIPTION
Use package interrogation feature from base class chrisapp version 2.0.0 so that `setup.py` becomes the single-source of truth for a ChRIS plugin's

- AUTHORS
- SELFPATH, SELFEXEC, EXECSHELL
- TITLE
- DESCRIPTION
- DOCUMENTATION (url)
- VERSION
- LICENSE