### PR TITLE
Split RUN to leverage docker build cache

### DIFF
--- a/{{cookiecutter.app_repo_name}}/Dockerfile
+++ b/{{cookiecutter.app_repo_name}}/Dockerfile
@@ -21,16 +21,16 @@
 #   docker run -ti -e HOST_IP=$(ip route | grep -v docker | awk '{if(NF==11) print $9}') --entrypoint /bin/bash local/{{ cookiecutter.app_repo_name }}
 #
 
-FROM fnndsc/ubuntu-python3:latest
+FROM python:3.9.1-buster
 MAINTAINER fnndsc "dev@babymri.org"
 
 WORKDIR /usr/local/src
 
 COPY requirements.txt .
-RUN ["pip", "--disable-pip-version-check", "install", "-r", "requirements.txt"]
+RUN ["pip", "install", "-r", "requirements.txt"]
 
 COPY . .
-RUN ["pip", "--disable-pip-version-check", "install", "."]
+RUN ["pip", "install", "."]
 
 WORKDIR /usr/local/bin
 CMD ["{{ cookiecutter.app_name }}", "--help"]

--- a/{{cookiecutter.app_repo_name}}/Dockerfile
+++ b/{{cookiecutter.app_repo_name}}/Dockerfile
@@ -25,9 +25,12 @@ FROM fnndsc/ubuntu-python3:latest
 MAINTAINER fnndsc "dev@babymri.org"
 
 WORKDIR /usr/local/src
+
+COPY requirements.txt .
+RUN ["pip", "--disable-pip-version-check", "install", "-r", "requirements.txt"]
+
 COPY . .
-RUN pip --disable-pip-version-check install -r requirements.txt \
-    && pip --disable-pip-version-check install .
+RUN ["pip", "--disable-pip-version-check", "install", "."]
 
 WORKDIR /usr/local/bin
 CMD ["{{ cookiecutter.app_name }}", "--help"]

--- a/{{cookiecutter.app_repo_name}}/Dockerfile
+++ b/{{cookiecutter.app_repo_name}}/Dockerfile
@@ -22,7 +22,7 @@
 #
 
 FROM python:3.9.1-buster
-MAINTAINER fnndsc "dev@babymri.org"
+LABEL maintainer="{{ cookiecutter.author_name }} <{{ cookiecutter.author_email }}>"
 
 WORKDIR /usr/local/src
 


### PR DESCRIPTION
When application code is changed without changing `requirements.txt`, rebuilds can be hasty (<1s).

This comes at a consequence of more image layers, but it's not a big deal.

We are also changing to the official `python:buster` base image.

- debian is stable and easy to use
- python version is pinned
- base image is routinely updated and maintained, no need for `--disable-pip-version-check`